### PR TITLE
Handle coingecko 429 status code as 500.

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,12 +238,15 @@ async function request (options) {
       })
       res.on('end', () => {
         const body = chunks.join('')
-        const { statusCode } = res
+        const { statusCode = 0, res: response } = res
         try {
-          const json = JSON.parse(body)
-          if (statusCode < 200 || statusCode >= 400) {
+          if (Number(statusCode) === 429 && response.host.match('coingecko')) {
+            failure(new Error('request failed'), 500, {}, body, { 'Cache-Control': 'no-store' })
+          } else if (statusCode < 200 || statusCode >= 400) {
+            const json = JSON.parse(body)
             failure(new Error('request failed'), statusCode, json, body)
           } else {
+            const json = JSON.parse(body)
             resolve(json)
           }
         } catch (e) {


### PR DESCRIPTION
- Cloudfront will be hable to handle the 500 better than the 429
- The 429 makes it appear as though the service is down

https://github.com/brave-intl/currency/issues/39