### PR TITLE
Update version in package.json to 1.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave-intl/currency",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "caches currency trade rates for synchronous access",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Probably should have done this earlier.  I need to update the consumer of the package to use this version (1.6.7) before updating to 1.6.8 in https://github.com/brave-intl/currency/pull/54.