### PR TITLE
Bump version in package.json to 1.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brave-intl/currency",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "caches currency trade rates for synchronous access",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumping since I merged https://github.com/brave-intl/currency/pull/54.